### PR TITLE
[JENKINS-33095] Fix circular dependency issue

### DIFF
--- a/icon-set/pom.xml
+++ b/icon-set/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
   </description>
 
   <properties>
-    <stapler.version>1.227</stapler.version>
+    <stapler.version>1.236</stapler.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.520</version>
+    <version>1.609</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins.icon-shim</groupId>


### PR DESCRIPTION
[JENKINS-33095](https://issues.jenkins-ci.org/browse/JENKINS-33095)

The core version that icon-shim uses is old so when run on a newer core the plugin manager will add dependencies to plugins that have been split from core. This causes an unwanted circular dependency as `matrix-auth` was split from core post the original baseline and has a dependency on `cloudbees-folder`, which depends on `credentials`, which depends on `icon-shim` which causes all these plugins to not load causing massive headaches....

`SEVERE: found cycle in plugin dependencies: (root=Plugin:credentials, deactivating all involved) Plugin:credentials -> Plugin:icon-shim -> Plugin:matrix-auth -> Plugin:cloudbees-folder -> Plugin:credentials`

@reviewbybees
