### PR TITLE
[JENKINS-41306] Migrate to 2.x parent POM. Fix javadoc issues.

### DIFF
--- a/icon-set/src/main/java/org/jenkins/ui/icon/Icon.java
+++ b/icon-set/src/main/java/org/jenkins/ui/icon/Icon.java
@@ -25,6 +25,7 @@ package org.jenkins.ui.icon;
 
 import org.apache.commons.jelly.JellyContext;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -61,7 +62,7 @@ public class Icon {
 
     /**
      * Icon instance.
-     * <p/>
+     * <br><br>
      * Creates a {@link IconType#CORE core} icon.
      *
      * @param classSpec The icon class names.
@@ -122,7 +123,7 @@ public class Icon {
 
     /**
      * Get the qualified icon url.
-     * <p/>
+     * <br><br>
      * Qualifying the URL involves prefixing it depending on whether the icon is a core or plugin icon.
      * Core icons are prefixed with the
      *
@@ -188,7 +189,7 @@ public class Icon {
 
     /**
      * Generate a normalized CSS selector from the space separated list of icon class names.
-     * <p/>
+     * <br><br>
      * The normalized CSS selector is the list of class names, alphabetically sorted and dot separated.
      * This means that "icon-help icon-xlg" and "icon-xlg icon-help" have the same normalized
      * selector ".icon-help.icon-xlg".  Spaces are not relevant etc.
@@ -254,7 +255,7 @@ public class Icon {
         return originalUrl;
     }
 
-    private static class StringComparator implements Comparator<String> {
+    private static class StringComparator implements Comparator<String>, Serializable {
 
         @Override
         public int compare(String s1, String s2) {

--- a/icon-set/src/main/java/org/jenkins/ui/icon/IconSpec.java
+++ b/icon-set/src/main/java/org/jenkins/ui/icon/IconSpec.java
@@ -25,7 +25,7 @@ package org.jenkins.ui.icon;
 
 /**
  * Icon Specification.
- * <p/>
+ * <br><br>
  * Plugin extension points that implement/extend Action/ManagementLink should
  * also implement this interface.
  *
@@ -35,7 +35,7 @@ public interface IconSpec {
 
     /**
      * Get the Icon class specification e.g. 'icon-notepad'.
-     * <p/>
+     * <br><br>
      * Note: do <strong>NOT</strong> include icon size specifications (such as 'icon-sm').
      *
      * @return The Icon class specification e.g. 'icon-notepad'.

--- a/icon-set/src/main/java/org/jenkins/ui/icon/IconType.java
+++ b/icon-set/src/main/java/org/jenkins/ui/icon/IconType.java
@@ -37,7 +37,7 @@ public enum IconType {
 
     /**
      * Qualify the supplied icon url.
-     * <p/>
+     * <br><br>
      * Qualifying the URL involves prefixing it depending on whether the icon is a core or plugin icon.
      *
      * @param url The url to be qualified.

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -50,59 +50,7 @@ THE SOFTWARE.
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
-                    </message>
-                  </requireMavenVersion>
-                  <requireMavenVersion>
-                    <version>(,3.0),[3.0.4,)</version>
-                    <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release
-                      Plugin.
-                    </message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.2</version>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>true</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version>
+    <version>2.21</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
@@ -69,6 +69,11 @@ THE SOFTWARE.
       <name>Tom Fennelly</name>
     </developer>
   </developers>
+
+  <properties>
+    <jenkins.version>1.609</jenkins.version>
+    <java.level>6</java.level>
+  </properties>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@ THE SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
       </plugin>
     </plugins>
   </build>
@@ -87,14 +86,14 @@ THE SOFTWARE.
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
[JENKINS-41306](https://issues.jenkins-ci.org/browse/JENKINS-41306)

- Migrate to 2.x parent POM.
- Fix some Javadoc issues.
- Fix some Findbugs issues.

@reviewbybees @tfennelly 